### PR TITLE
Left and bottom coordinates of bbox should be included.

### DIFF
--- a/Seminar9/main.cpp
+++ b/Seminar9/main.cpp
@@ -105,14 +105,14 @@ int KDTree::CountPointsInBbox(
     ++count;
   }
   if (depth % 2 == 0) {
-    if (node->left && bbox.left < node->median.lon) {
+    if (node->left && bbox.left <= node->median.lon) {
       count += CountPointsInBbox(bbox, node->left, depth + 1);
     }
     if (node->right && node->median.lon < bbox.right) {
       count += CountPointsInBbox(bbox, node->right, depth + 1);
     }
   } else {
-    if (node->left && bbox.bottom < node->median.lat) {
+    if (node->left && bbox.bottom <= node->median.lat) {
       count += CountPointsInBbox(bbox, node->left, depth + 1);
     }
     if (node->right && node->median.lat < bbox.top) {


### PR DESCRIPTION
Consider the following case:
Points:
```
1. 1.
1. 2.
2. 1.
```

Bbox
```1. 1. 3. 3.```

Expected answer: 3.
Actual answer: 2.